### PR TITLE
Fixed : deprecations for Symfony 4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
   - hhvm
 
 cache:
@@ -16,24 +17,29 @@ cache:
 matrix:
   fast_finish: true
   include:
+    - php: 5.5
+      env: DEPENDENCIES="symfony/lts:^2"
     - php: 5.6
-      env: SYMFONY_VERSION=2.7.*
-    - php: 5.6
-      env: SYMFONY_VERSION=2.8.*
-    - php: 5.6
-      env: SYMFONY_VERSION=3.4.*
-    - php: 5.6
-      env: SYMFONY_VERSION=4.4.*
+      env: DEPENDENCIES="symfony/lts:^2"
+    - php: 7.0
+      env: DEPENDENCIES="symfony/lts:^3"
+    - php: 7.1
+      env: DEPENDENCIES="symfony/lts:^3"
+    - php: 7.2
+      env: DEPENDENCIES="symfony/lts:^4"
+    - php: 7.3
+      env: DEPENDENCIES="symfony/lts:^4"
+    - php: 7.4
+      env: DEPENDENCIES="symfony/lts:^4"
   allow_failures:
     - php: hhvm
 
 before_install:
-  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "memory_limit=3072M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; else composer require "symfony/symfony:dev-master"; fi;
-  - if [ "$SYMFONY_VERSION" = "3.1.*@dev" ] || [ "$SYMFONY_VERSION" = "3.2.*@dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "memory_limit=4G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
+  - if [ "$DEPENDENCIES" != "" ]; then composer require --no-update $DEPENDENCIES; fi;
 
 install:
-  - composer update --dev --prefer-source
+  - composer update --prefer-dist --no-interaction
 
 script: phpunit
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
   - hhvm
 
 cache:
@@ -19,11 +21,9 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION=2.8.*
     - php: 5.6
-      env: SYMFONY_VERSION=3.0.*
+      env: SYMFONY_VERSION=3.4.*
     - php: 5.6
-      env: SYMFONY_VERSION=3.1.*@dev
-    - php: 5.6
-      env: SYMFONY_VERSION=3.2.*@dev
+      env: SYMFONY_VERSION=4.4.*
   allow_failures:
     - php: hhvm
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_install:
 install:
   - composer update --prefer-dist --no-interaction
 
-script: phpunit
+script: vendor/bin/phpunit
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ matrix:
 before_install:
   - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "memory_limit=4G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
   - if [ "$DEPENDENCIES" != "" ]; then composer require --no-update $DEPENDENCIES; fi;
+  - if [ "DEPENDENCIES" = "symfony/lts:^4" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
 
 install:
   - composer update --prefer-dist --no-interaction
@@ -46,3 +47,6 @@ script: vendor/bin/phpunit
 notifications:
   email:
     - composieux@ekino.com
+
+# Because of PHP 5.5
+dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   - if [ "DEPENDENCIES" = "symfony/lts:^4" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
 
 install:
-  - composer update --prefer-dist --no-interaction
+  - composer update --dev --prefer-source --no-interaction
 
 script: vendor/bin/phpunit
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,8 +30,12 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('ekino_wordpress');
+        $treeBuilder = new TreeBuilder('ekino_wordpress');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('ekino_wordpress');
+        }
 
         $rootNode
             ->children()

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ ekino_wordpress:
     table_prefix: "wp_" # If you have a specific Wordpress table prefix
     wordpress_directory: "%kernel.root_dir%/../../wordpress"
     load_twig_extension: true # If you want to enable native WordPress functions (ie : get_option() => wp_get_option())
-    enable_wordpress_listener: false # If you want to disable the WordPress request listener
+    enable_wordpress_listener: true # If you want to disable the WordPress request listener
     security:
         firewall_name: "secured_area" # This is the firewall default name
         login_url: "/wp-login.php" # Absolute URL to the wordpress login page
@@ -364,3 +364,5 @@ Twig functions available in this bundle:
 
 {{ wp_get_footer() }}
 ```
+
+You can see an example for [TwentyTwenty theme](Resources/docs/twig_example.md).

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -8,7 +8,7 @@
 
         <!-- Services -->
 
-        <service id="ekino.wordpress.wordpress" class="Ekino\WordpressBundle\Wordpress\Wordpress">
+        <service id="ekino.wordpress.wordpress" class="Ekino\WordpressBundle\Wordpress\Wordpress" public="true">
             <argument>%ekino.wordpress.install_directory%</argument>
             <argument>%ekino.wordpress.globals%</argument>
         </service>
@@ -16,7 +16,7 @@
 
         <!-- Subscribers -->
 
-        <service id="ekino.wordpress.subscriber.table_prefix_subscriber" class="Ekino\WordpressBundle\Subscriber\TablePrefixSubscriber">
+        <service id="ekino.wordpress.subscriber.table_prefix_subscriber" class="Ekino\WordpressBundle\Subscriber\TablePrefixSubscriber" public="true">
             <tag name="doctrine.event_subscriber" />
 
             <argument />

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -12,6 +12,7 @@
             <argument>%ekino.wordpress.install_directory%</argument>
             <argument>%ekino.wordpress.globals%</argument>
         </service>
+        <service id="Ekino\WordpressBundle\Wordpress\Wordpress" alias="ekino.wordpress.wordpress"/>
 
         <!-- Subscribers -->
 
@@ -20,11 +21,13 @@
 
             <argument />
         </service>
+        <service id="Ekino\WordpressBundle\Subscriber\TablePrefixSubscriber" alias="ekino.wordpress.subscriber.table_prefix_subscriber"/>
 
         <!-- Security -->
 
         <service id="ekino.wordpress.security.entry_point" class="Ekino\WordpressBundle\Security\WordpressEntryPoint" public="true">
             <argument>%ekino.wordpress.login_url%</argument>
         </service>
+        <service id="Ekino\WordpressBundle\Security\WordpressEntryPoint" alias="ekino.wordpress.security.entry_point"/>
     </services>
 </container>

--- a/Resources/docs/twig_example.md
+++ b/Resources/docs/twig_example.md
@@ -1,0 +1,74 @@
+# Example for Twig
+
+## Theme Wordpress TwentyTwenty
+
+This is a dummy example for a page controlled by Symfony.
+
+### Twig
+
+```jinja
+{{ wp_get_header() }}
+
+<main id="site-content" role="main">
+
+    <article class="post-1 page type-page status-publish hentry">
+
+        <header class="entry-header has-text-align-center header-footer-group">
+
+            <div class="entry-header-inner section-inner medium">
+
+                {% if archive_title is defined and archive_title is not empty %}
+                    <h1 class="entry-title">{{ archive_title }}</h1>
+                {% endif %}
+
+                {% if archive_subtitle is defined and archive_subtitle is not empty %}
+                    <div class="entry-subtitle section-inner thin max-percentage intro-text">{{ archive_subtitle|striptags('strong') }}</div>
+                {% endif %}
+
+            </div><!-- .entry-header-inner -->
+
+        </header>
+
+        <div class="post-inner thin ">
+
+            <div class="entry-content">
+                {{ msg|raw }}
+            </div>
+        </div>
+
+    </article>
+</main>
+
+{{ wp_get_template_part( 'template-parts/footer-menus-widgets' ) }}
+
+{{ wp_get_footer() }}
+```
+
+### Controller
+
+The route _/example_ is dealt with Symfony.
+
+```php
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Annotation\Route;
+
+class DefaultController extends AbstractController
+{
+    /**
+     * @Route("/example", name="sf_example", methods={"GET"})
+     */
+    public function index()
+    {
+        return $this->render('index.html.twig', [
+            'archive_title' => 'Archive title',
+            'archive_subtitle' => 'Archive subtitle',
+            'msg' => '<p>Hello world!</p>'
+        ]);
+    }
+}
+
+```

--- a/Tests/Controller/WordpressControllerTest.php
+++ b/Tests/Controller/WordpressControllerTest.php
@@ -17,7 +17,7 @@ namespace Ekino\WordpressBundle\Tests\Controller;
  *
  * @author Vincent Composieux <composieux@ekino.com>
  */
-class WordpressControllerTest extends \PHPUnit_Framework_TestCase
+class WordpressControllerTest extends \PHPUnit\Framework\TestCase
 {
     protected $wp_query;
 

--- a/Tests/Entity/CommentMetaTest.php
+++ b/Tests/Entity/CommentMetaTest.php
@@ -20,7 +20,7 @@ use Ekino\WordpressBundle\Entity\CommentMeta;
  *
  * @author Vincent Composieux <composieux@ekino.com>
  */
-class CommentMetaTest extends \PHPUnit_Framework_TestCase
+class CommentMetaTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test entity getters & setters.

--- a/Tests/Entity/CommentTest.php
+++ b/Tests/Entity/CommentTest.php
@@ -21,7 +21,7 @@ use Ekino\WordpressBundle\Entity\User;
  *
  * @author Vincent Composieux <composieux@ekino.com>
  */
-class CommentTest extends \PHPUnit_Framework_TestCase
+class CommentTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test entity getters & setters.

--- a/Tests/Entity/LinkTest.php
+++ b/Tests/Entity/LinkTest.php
@@ -19,7 +19,7 @@ use Ekino\WordpressBundle\Entity\Link;
  *
  * @author Vincent Composieux <composieux@ekino.com>
  */
-class LinkTest extends \PHPUnit_Framework_TestCase
+class LinkTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test entity getters & setters.

--- a/Tests/Entity/OptionTest.php
+++ b/Tests/Entity/OptionTest.php
@@ -19,7 +19,7 @@ use Ekino\WordpressBundle\Entity\Option;
  *
  * @author Vincent Composieux <composieux@ekino.com>
  */
-class OptionTest extends \PHPUnit_Framework_TestCase
+class OptionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test entity getters & setters.

--- a/Tests/Entity/PostMetaTest.php
+++ b/Tests/Entity/PostMetaTest.php
@@ -20,7 +20,7 @@ use Ekino\WordpressBundle\Entity\PostMeta;
  *
  * @author Vincent Composieux <composieux@ekino.com>
  */
-class PostMetaTest extends \PHPUnit_Framework_TestCase
+class PostMetaTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test entity getters & setters.

--- a/Tests/Entity/PostTest.php
+++ b/Tests/Entity/PostTest.php
@@ -22,7 +22,7 @@ use Ekino\WordpressBundle\Entity\User;
  *
  * @author Vincent Composieux <composieux@ekino.com>
  */
-class PostTest extends \PHPUnit_Framework_TestCase
+class PostTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test entity getters & setters.

--- a/Tests/Entity/TermRelationshipsTest.php
+++ b/Tests/Entity/TermRelationshipsTest.php
@@ -20,7 +20,7 @@ use Ekino\WordpressBundle\Entity\TermTaxonomy;
  *
  * @author Vincent Composieux <composieux@ekino.com>
  */
-class TermRelationshipsTest extends \PHPUnit_Framework_TestCase
+class TermRelationshipsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test entity getters & setters.

--- a/Tests/Entity/TermTaxonomyTest.php
+++ b/Tests/Entity/TermTaxonomyTest.php
@@ -20,7 +20,7 @@ use Ekino\WordpressBundle\Entity\TermTaxonomy;
  *
  * @author Vincent Composieux <composieux@ekino.com>
  */
-class TermTaxonomyTest extends \PHPUnit_Framework_TestCase
+class TermTaxonomyTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test entity getters & setters.

--- a/Tests/Entity/TermTest.php
+++ b/Tests/Entity/TermTest.php
@@ -19,7 +19,7 @@ use Ekino\WordpressBundle\Entity\Term;
  *
  * @author Vincent Composieux <composieux@ekino.com>
  */
-class TermTest extends \PHPUnit_Framework_TestCase
+class TermTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test entity getters & setters.

--- a/Tests/Entity/UserMetaTest.php
+++ b/Tests/Entity/UserMetaTest.php
@@ -20,7 +20,7 @@ use Ekino\WordpressBundle\Entity\UserMeta;
  *
  * @author Vincent Composieux <composieux@ekino.com>
  */
-class UserMetaTest extends \PHPUnit_Framework_TestCase
+class UserMetaTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test entity getters & setters.

--- a/Tests/Entity/UserTest.php
+++ b/Tests/Entity/UserTest.php
@@ -21,7 +21,7 @@ use Ekino\WordpressBundle\Entity\UserMeta;
  *
  * @author Vincent Composieux <composieux@ekino.com>
  */
-class UserTest extends \PHPUnit_Framework_TestCase
+class UserTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test entity getters & setters.

--- a/Tests/Event/Hook/UserHookListenerTest.php
+++ b/Tests/Event/Hook/UserHookListenerTest.php
@@ -17,7 +17,7 @@ use Ekino\WordpressBundle\Event\Hook\UserHookListener;
  *
  * @author Vincent Composieux <composieux@ekino.com>
  */
-class UserHookListenerTest extends \PHPUnit_Framework_TestCase
+class UserHookListenerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Ekino\WordpressBundle\Manager\UserManager

--- a/Tests/Event/Subscriber/I18n/I18nSubscriberTest.php
+++ b/Tests/Event/Subscriber/I18n/I18nSubscriberTest.php
@@ -15,7 +15,7 @@ use Ekino\WordpressBundle\Event\Subscriber\I18n\I18nSubscriber;
 /**
  * Class RequestSubscriberTest.
  */
-class I18nSubscriberTest extends \PHPUnit_Framework_TestCase
+class I18nSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     protected $defaultLanguage;
     protected $cookieName;

--- a/Tests/Event/Subscriber/WordpressResponseSubscriberTest.php
+++ b/Tests/Event/Subscriber/WordpressResponseSubscriberTest.php
@@ -14,7 +14,7 @@ use Ekino\WordpressBundle\Event\Subscriber\WordpressResponseSubscriber;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-class WordpressResponseSubscriberTest extends \PHPUnit_Framework_TestCase
+class WordpressResponseSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     protected $event;
     protected $response;

--- a/Tests/Event/WordpressEventTest.php
+++ b/Tests/Event/WordpressEventTest.php
@@ -19,7 +19,7 @@ use Ekino\WordpressBundle\Event\WordpressEvent;
  *
  * @author Vincent Composieux <composieux@ekino.com>
  */
-class WordpressEventTest extends \PHPUnit_Framework_TestCase
+class WordpressEventTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Tests WordpressEvent constructor parameters.

--- a/Tests/Listener/WordpressRequestListenerTest.php
+++ b/Tests/Listener/WordpressRequestListenerTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
  *
  * @author Vincent Composieux <composieux@ekino.com>
  */
-class WordpressRequestListenerTest extends \PHPUnit_Framework_TestCase
+class WordpressRequestListenerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Ekino\WordpressBundle\Listener\WordpressRequestListener

--- a/Tests/Manager/OptionManagerTest.php
+++ b/Tests/Manager/OptionManagerTest.php
@@ -19,7 +19,7 @@ use Ekino\WordpressBundle\Repository\OptionRepository;
  *
  * @author Xavier Coureau <xav.is@2cool4school.fr>
  */
-class OptionManagerTest extends \PHPUnit_Framework_TestCase
+class OptionManagerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var EntityManager

--- a/Tests/Manager/PostManagerTest.php
+++ b/Tests/Manager/PostManagerTest.php
@@ -21,7 +21,7 @@ use Ekino\WordpressBundle\Repository\PostRepository;
  *
  * @author Guillaume Leclercq <g.leclercq12@gmail.com>
  */
-class PostManagerTest extends \PHPUnit_Framework_TestCase
+class PostManagerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var EntityManager

--- a/Tests/Manager/PostMetaManagerTest.php
+++ b/Tests/Manager/PostMetaManagerTest.php
@@ -20,7 +20,7 @@ use Ekino\WordpressBundle\Repository\PostMetaRepository;
  *
  * @author Xavier Coureau <xav.is@2cool4school.fr>
  */
-class PostMetaManagerTest extends \PHPUnit_Framework_TestCase
+class PostMetaManagerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var EntityManager

--- a/Tests/Security/WordPressEntryPointTest.php
+++ b/Tests/Security/WordPressEntryPointTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
  *
  * @author Jérôme Tamarelle <jerome@tamarelle.net>
  */
-class WordPressEntryPointTest extends \PHPUnit_Framework_TestCase
+class WordPressEntryPointTest extends \PHPUnit\Framework\TestCase
 {
     public function testEntryPoint()
     {

--- a/Tests/Twig/Extension/OptionExtensionTest.php
+++ b/Tests/Twig/Extension/OptionExtensionTest.php
@@ -17,7 +17,7 @@ use Ekino\WordpressBundle\Twig\Extension\OptionExtension;
  *
  * @author Xavier Coureau <xav.is@2cool4school.fr>
  */
-class OptionExtensionTest extends \PHPUnit_Framework_TestCase
+class OptionExtensionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject

--- a/Tests/Twig/Extension/OptionExtensionTest.php
+++ b/Tests/Twig/Extension/OptionExtensionTest.php
@@ -31,7 +31,7 @@ class OptionExtensionTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('\Twig_Extension')) {
+        if (!class_exists('\Twig\Extension\AbstractExtension')) {
             $this->markTestSkipped('Twig is not enabled');
         }
 
@@ -46,7 +46,7 @@ class OptionExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testGetFunctions()
     {
-        $this->assertContainsOnly('\Twig_SimpleFunction', $this->extension->getFunctions());
+        $this->assertContainsOnly('\Twig\TwigFunction', $this->extension->getFunctions());
     }
 
     /**

--- a/Tests/Twig/Extension/PostExtensionTest.php
+++ b/Tests/Twig/Extension/PostExtensionTest.php
@@ -24,7 +24,7 @@ class PostExtensionTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('\Twig_Extension')) {
+        if (!class_exists('\Twig\Extension\AbstractExtension')) {
             $this->markTestSkipped('Twig is not enabled');
         }
 
@@ -41,7 +41,7 @@ class PostExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testGetFunctions()
     {
-        $this->assertContainsOnly('\Twig_SimpleFunction', $this->postExtension->getFunctions());
+        $this->assertContainsOnly('\Twig\TwigFunction', $this->postExtension->getFunctions());
     }
 
     public function testReplacePostArguments()

--- a/Tests/Twig/Extension/PostExtensionTest.php
+++ b/Tests/Twig/Extension/PostExtensionTest.php
@@ -11,8 +11,9 @@
 namespace Ekino\WordpressBundle\Tests\Twig\Extension;
 
 use Ekino\WordpressBundle\Twig\Extension\PostExtension;
+use PHPUnit\Framework\TestCase;
 
-class PostExtensionTest extends \PHPUnit_Framework_TestCase
+class PostExtensionTest extends TestCase
 {
     protected $postManager;
     protected $optionExtension;
@@ -69,7 +70,7 @@ class PostExtensionTest extends \PHPUnit_Framework_TestCase
             ->method('find')
             ->will($this->returnValue(false));
 
-        $this->setExpectedException('\UnexpectedValueException');
+        $this->expectException(\UnexpectedValueException::class);
         $this->postExtension->getPermalink(12);
     }
 

--- a/Tests/Twig/Extension/PostMetaExtensionTest.php
+++ b/Tests/Twig/Extension/PostMetaExtensionTest.php
@@ -38,7 +38,7 @@ namespace Ekino\WordpressBundle\Tests\Twig\Extension {
 
         protected function setUp()
         {
-            if (!class_exists('\Twig_Extension')) {
+            if (!class_exists('\Twig\Extension\AbstractExtension')) {
                 $this->markTestSkipped('Twig is not enabled');
             }
 
@@ -59,7 +59,7 @@ namespace Ekino\WordpressBundle\Tests\Twig\Extension {
          */
         public function testGetFunctions()
         {
-            $this->assertContainsOnly('\Twig_SimpleFunction', $this->extension->getFunctions());
+            $this->assertContainsOnly('\Twig\TwigFunction', $this->extension->getFunctions());
         }
 
         /**

--- a/Tests/Twig/Extension/PostMetaExtensionTest.php
+++ b/Tests/Twig/Extension/PostMetaExtensionTest.php
@@ -24,7 +24,7 @@ namespace Ekino\WordpressBundle\Tests\Twig\Extension {
      *
      * @author Xavier Coureau <xav.is@2cool4school.fr>
      */
-    class PostMetaExtensionTest extends \PHPUnit_Framework_TestCase
+    class PostMetaExtensionTest extends \PHPUnit\Framework\TestCase
     {
         /**
          * @var \PHPUnit_Framework_MockObject_MockObject

--- a/Tests/Twig/Extension/ThemeExtensionTest.php
+++ b/Tests/Twig/Extension/ThemeExtensionTest.php
@@ -70,7 +70,7 @@ namespace Ekino\WordpressBundle\Tests\Twig\Extension {
      *
      * @author Vincent Composieux <vincent.composieux@gmail.com>
      */
-    class ThemeExtensionTest extends \PHPUnit_Framework_TestCase
+    class ThemeExtensionTest extends \PHPUnit\Framework\TestCase
     {
         /**
          * @var ThemeExtension

--- a/Tests/Twig/Extension/ThemeExtensionTest.php
+++ b/Tests/Twig/Extension/ThemeExtensionTest.php
@@ -82,7 +82,7 @@ namespace Ekino\WordpressBundle\Tests\Twig\Extension {
          */
         protected function setUp()
         {
-            if (!class_exists('\Twig_Extension')) {
+            if (!class_exists('\Twig\Extension\AbstractExtension')) {
                 $this->markTestSkipped('Twig is not enabled');
             }
 
@@ -102,7 +102,7 @@ namespace Ekino\WordpressBundle\Tests\Twig\Extension {
          */
         public function testGetFunctions()
         {
-            $this->assertContainsOnly('\Twig_SimpleFunction', $this->extension->getFunctions());
+            $this->assertContainsOnly('\Twig\TwigFunction', $this->extension->getFunctions());
         }
 
         /**

--- a/Tests/Wordpress/WordpressTest.php
+++ b/Tests/Wordpress/WordpressTest.php
@@ -19,7 +19,7 @@ use Ekino\WordpressBundle\Wordpress\Wordpress;
  *
  * @author Vincent Composieux <composieux@ekino.com>
  */
-class WordpressTest extends \PHPUnit_Framework_TestCase
+class WordpressTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Ekino\WordpressBundle\Wordpress\Wordpress
@@ -79,7 +79,7 @@ class WordpressTest extends \PHPUnit_Framework_TestCase
      */
     public function testExceptionWhenDirectoryNotFound()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
 
         $wordpress = new Wordpress('/a/path/that/does/not/exists', ['wp_test_global1', 'wp_test_global2']);
         $wordpress->initialize();

--- a/Twig/Extension/CommentExtension.php
+++ b/Twig/Extension/CommentExtension.php
@@ -12,6 +12,8 @@ namespace Ekino\WordpressBundle\Twig\Extension;
 
 use Ekino\WordpressBundle\Manager\CommentManager;
 use Ekino\WordpressBundle\Model\Comment;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Class CommentExtension.
@@ -20,7 +22,7 @@ use Ekino\WordpressBundle\Model\Comment;
  *
  * @author Xavier Coureau <xav@takeatea.com>
  */
-class CommentExtension extends \Twig_Extension
+class CommentExtension extends AbstractExtension
 {
     /**
      * @var CommentManager
@@ -51,7 +53,7 @@ class CommentExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('wp_get_comment_author_link', [$this, 'getCommentAuthorLink'], ['is_safe' => ['html']]),
+            new TwigFunction('wp_get_comment_author_link', [$this, 'getCommentAuthorLink'], ['is_safe' => ['html']]),
         ];
     }
 

--- a/Twig/Extension/OptionExtension.php
+++ b/Twig/Extension/OptionExtension.php
@@ -11,13 +11,15 @@
 namespace Ekino\WordpressBundle\Twig\Extension;
 
 use Ekino\WordpressBundle\Manager\OptionManager;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Class OptionExtension.
  *
  * This extension provides native Wordpress functions into Twig.
  */
-class OptionExtension extends \Twig_Extension
+class OptionExtension extends AbstractExtension
 {
     /**
      * @var OptionManager
@@ -46,8 +48,8 @@ class OptionExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('wp_get_option', [$this, 'getOption']),
-            new \Twig_SimpleFunction('wp_is_active_sidebar', [$this, 'isActiveSidebar']),
+            new TwigFunction('wp_get_option', [$this, 'getOption']),
+            new TwigFunction('wp_is_active_sidebar', [$this, 'isActiveSidebar']),
         ];
     }
 

--- a/Twig/Extension/PostExtension.php
+++ b/Twig/Extension/PostExtension.php
@@ -12,13 +12,15 @@ namespace Ekino\WordpressBundle\Twig\Extension;
 
 use Ekino\WordpressBundle\Entity\Post;
 use Ekino\WordpressBundle\Manager\PostManager;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Class PostExtension.
  *
  * This extension provides native Wordpress functions into Twig.
  */
-class PostExtension extends \Twig_Extension
+class PostExtension extends AbstractExtension
 {
     /**
      * @var PostManager
@@ -61,11 +63,11 @@ class PostExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('wp_comments_open', [$this, 'isCommentingOpened']),
-            new \Twig_SimpleFunction('wp_get_permalink', [$this, 'getPermalink']),
-            new \Twig_SimpleFunction('wp_get_the_post_thumbnail_url', [$this, 'getThumbnailUrl']),
-            new \Twig_SimpleFunction('wp_have_comments', [$this, 'haveComments']),
-            new \Twig_SimpleFunction('wp_post_password_required', [$this, 'isPostPasswordRequired'], ['needs_context' => true]),
+            new TwigFunction('wp_comments_open', [$this, 'isCommentingOpened']),
+            new TwigFunction('wp_get_permalink', [$this, 'getPermalink']),
+            new TwigFunction('wp_get_the_post_thumbnail_url', [$this, 'getThumbnailUrl']),
+            new TwigFunction('wp_have_comments', [$this, 'haveComments']),
+            new TwigFunction('wp_post_password_required', [$this, 'isPostPasswordRequired'], ['needs_context' => true]),
         ];
     }
 

--- a/Twig/Extension/PostMetaExtension.php
+++ b/Twig/Extension/PostMetaExtension.php
@@ -11,13 +11,15 @@
 namespace Ekino\WordpressBundle\Twig\Extension;
 
 use Ekino\WordpressBundle\Manager\PostMetaManager;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Class PostMetaExtension.
  *
  * This extension provides native Wordpress functions into Twig.
  */
-class PostMetaExtension extends \Twig_Extension
+class PostMetaExtension extends AbstractExtension
 {
     /**
      * @var PostMetaManager
@@ -48,8 +50,8 @@ class PostMetaExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('wp_get_post_meta', [$this, 'getPostMeta']),
-            new \Twig_SimpleFunction('wp_get_image_url_from_id', [$this, 'getImageUrlFromId']),
+            new TwigFunction('wp_get_post_meta', [$this, 'getPostMeta']),
+            new TwigFunction('wp_get_image_url_from_id', [$this, 'getImageUrlFromId']),
         ];
     }
 

--- a/Twig/Extension/TermTaxonomyExtension.php
+++ b/Twig/Extension/TermTaxonomyExtension.php
@@ -12,6 +12,8 @@ namespace Ekino\WordpressBundle\Twig\Extension;
 
 use Ekino\WordpressBundle\Manager\OptionManager;
 use Ekino\WordpressBundle\Model\TermTaxonomy;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Class TermTaxonomyExtension.
@@ -20,7 +22,7 @@ use Ekino\WordpressBundle\Model\TermTaxonomy;
  *
  * @author Xavier Coureau <xav@takeatea.com>
  */
-class TermTaxonomyExtension extends \Twig_Extension
+class TermTaxonomyExtension extends AbstractExtension
 {
     /**
      * @var OptionManager
@@ -41,7 +43,7 @@ class TermTaxonomyExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('wp_get_term_link', [$this, 'getTermLink']),
+            new TwigFunction('wp_get_term_link', [$this, 'getTermLink']),
         ];
     }
 

--- a/Twig/Extension/ThemeExtension.php
+++ b/Twig/Extension/ThemeExtension.php
@@ -10,6 +10,9 @@
 
 namespace Ekino\WordpressBundle\Twig\Extension;
 
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
 /**
  * Class ThemeExtension.
  *
@@ -17,7 +20,7 @@ namespace Ekino\WordpressBundle\Twig\Extension;
  *
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
-class ThemeExtension extends \Twig_Extension
+class ThemeExtension extends AbstractExtension
 {
     /**
      * Returns the name of the extension.
@@ -35,10 +38,10 @@ class ThemeExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('wp_get_header', [$this, 'getHeader'], ['is_safe' => ['html']]),
-            new \Twig_SimpleFunction('wp_get_sidebar', [$this, 'getSidebar'], ['is_safe' => ['html']]),
-            new \Twig_SimpleFunction('wp_get_footer', [$this, 'getFooter'], ['is_safe' => ['html']]),
-            new \Twig_SimpleFunction('wp_get_template_part', [$this, 'getTemplatePart'], ['is_safe' => ['html']]),
+            new TwigFunction('wp_get_header', [$this, 'getHeader'], ['is_safe' => ['html']]),
+            new TwigFunction('wp_get_sidebar', [$this, 'getSidebar'], ['is_safe' => ['html']]),
+            new TwigFunction('wp_get_footer', [$this, 'getFooter'], ['is_safe' => ['html']]),
+            new TwigFunction('wp_get_template_part', [$this, 'getTemplatePart'], ['is_safe' => ['html']]),
         ];
     }
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "hautelook/phpass": "0.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7|^6.5|^7.0",
+        "phpunit/phpunit": "^4.5|^5.7|^6.5|^7.0",
         "twig/twig": "^1.41.0|^2.0|^3.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "doctrine/orm": "^2.2",
         "hautelook/phpass": "0.3"
     },
-    "suggest": {
-        "twig/twig": ""
+    "require-dev": {
+        "twig/twig": "^1.41.0|^2.0|^3.0"
     },
     "autoload": {
         "psr-4": { "Ekino\\WordpressBundle\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "hautelook/phpass": "0.3"
     },
     "require-dev": {
+        "phpunit/phpunit": "^5.7|^6.5|^7.0",
         "twig/twig": "^1.41.0|^2.0|^3.0"
     },
     "autoload": {


### PR DESCRIPTION
This PR fixes the deprecations for Symfony 4.4, including PHPUnit and Twig deprecated (and removed) classes in 3.0.

This shall close #139 and possibly some other issue.
There should not have any problem with backward compatibilty. Basic implementation has been verified with Wordpress 5.3.2 and Symfony 4.4.

Travis config file has been updated.